### PR TITLE
Restyle tarot compatibility page with animated experience

### DIFF
--- a/css/reading.css
+++ b/css/reading.css
@@ -1,372 +1,500 @@
-@import url('https://fonts.googleapis.com/css?family=Cinzel|Slabo+27px');
+:root {
+  --bg-start: #150725;
+  --bg-end: #071732;
+  --accent: #c89bff;
+  --accent-strong: #7f7bff;
+  --text-primary: #f4f0ff;
+  --text-muted: rgba(244, 240, 255, 0.75);
+  --panel-bg: rgba(17, 13, 34, 0.55);
+  --panel-border: rgba(200, 155, 255, 0.18);
+  --shadow-strong: 0 25px 55px rgba(7, 10, 38, 0.55);
+  --shadow-soft: 0 18px 45px rgba(10, 15, 45, 0.35);
+  --card-glow: 0 0 0 1px rgba(200, 155, 255, 0.2);
+  --glass-blur: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
 
 body {
-  background-color: #D4E5EB;
-  font-family: 'Slabo 27px', serif;
-  height:100%;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Poppins', sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(200, 155, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(127, 123, 255, 0.25), transparent 50%),
+    linear-gradient(135deg, var(--bg-start), var(--bg-end));
+  color: var(--text-primary);
+  position: relative;
+  overflow-x: hidden;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Cinzel', serif;
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.14) 1px, transparent 1px);
+  background-size: 120px 120px;
+  opacity: 0.25;
+  pointer-events: none;
+  z-index: 0;
+  animation: twinkle 18s linear infinite;
 }
 
-.modal_card {
-    height:70%;
-    width:70%;
-    display: flex;
-    align-items: center;ß
-    justify-content: center;
-    margin-left:auto;
-    margin-right:auto;
-    margin-bottom:0.5em;
+@keyframes twinkle {
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  to {
+    transform: translate3d(-40px, -30px, 0) scale(1.02);
+  }
 }
 
-.drawn_card {
-  max-height:194px;
-  max-width:112px;
-  display:flex;
-  margin-left:.01em;
-  margin-right:.01em;
-  margin-bottom:auto;
-  border-radius:10px;
-  margin-top:0.01em;
+a {
+  color: inherit;
 }
 
-.flipped {
-    transform: rotate(180deg);
+a:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
 }
 
-.drawn_card:hover {
-  cursor:pointer;
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  padding: clamp(1.5rem, 4vw, 4rem);
+  position: relative;
+  z-index: 1;
 }
 
-.header > h1:hover {
-  cursor:pointer;
-}
-/*Style for the text above the cards*/
-.card_position {
-    font-weight:bold;
-    font-size:.7em;
-    max-width:109px;
-    text-align:center;
-    margin-bottom:0;
-    margin-top:0;
+.hero {
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
 }
 
-.wrapper {
-  flex-grow:1;
-  display:grid;
-  grid-row-gap:0;
-  grid-template-areas:
-  "header"
-  "spread_selection"
-  "deck"
-  "spreads"
-  "footer"
+.hero__brand {
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  text-decoration: none;
+  color: var(--text-primary);
+  text-shadow: 0 0 25px rgba(200, 155, 255, 0.45);
+  transition: transform 0.4s ease, text-shadow 0.4s ease;
 }
 
-.header {
-  grid-area:header;
-  margin:1em;
+.hero__brand:hover {
+  transform: translateY(-3px);
+  text-shadow: 0 0 35px rgba(200, 155, 255, 0.65);
 }
 
-.rule_of_three {
-    grid-area: rule_of_three;
+.hero__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 2.2vw, 1.2rem);
 }
 
-.true_love {
-    grid-area:true_love;
+.layout {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
 }
 
-.success {
-    grid-area:success;
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(var(--glass-blur));
+  position: relative;
+  overflow: hidden;
 }
 
-.deckspot {
-    grid-area:deck;
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  pointer-events: none;
 }
 
-.spread_display {
-    grid-area:spreads;
+.panel__title,
+.panel__subtitle,
+.results__title,
+.results__subtitle {
+  font-family: 'Cinzel Decorative', cursive;
+  letter-spacing: 0.04em;
+  margin-top: 0;
+  color: var(--text-primary);
 }
 
-.footer {
-  grid-area: footer;
-  text-align:center;
+.panel__title {
+  font-size: clamp(1.9rem, 5vw, 2.8rem);
+  margin-bottom: 1rem;
 }
 
-.header {
-    grid-row: 1;
-    text-align:center;
+.panel__subtitle,
+.results__subtitle {
+  font-size: clamp(1.35rem, 3.5vw, 1.75rem);
+  margin-bottom: 1.2rem;
+}
+
+.panel__text {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.reading-form {
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+}
+
+.form-card {
+  margin: 0;
+  border: 1px solid rgba(200, 155, 255, 0.25);
+  border-radius: 20px;
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  background: rgba(20, 16, 38, 0.65);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.form-card legend {
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: 1.2rem;
+  padding: 0 0.4rem;
+  color: var(--accent);
+}
+
+.form-label {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(200, 155, 255, 0.3);
+  background: rgba(12, 10, 26, 0.75);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(200, 155, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+.form-input::placeholder {
+  color: rgba(244, 240, 255, 0.45);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.cta-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.95rem 2.8rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  font-family: 'Poppins', sans-serif;
+  color: #0c0a1a;
+  background: linear-gradient(135deg, #e6d0ff 0%, #8ab4ff 50%, #6a60ff 100%);
+  box-shadow: 0 18px 40px rgba(130, 106, 255, 0.45), 0 0 35px rgba(200, 155, 255, 0.55);
+  cursor: pointer;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.cta-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.35), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.cta-button:hover {
+  transform: translateY(-3px) scale(1.03);
+  box-shadow: 0 25px 55px rgba(130, 106, 255, 0.5), 0 0 45px rgba(200, 155, 255, 0.65);
+}
+
+.cta-button:hover::after {
+  opacity: 1;
+}
+
+.cta-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 4px;
+}
+
+.cta-button--drawing {
+  animation: cardDraw 0.7s ease;
+}
+
+@keyframes cardDraw {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  40% {
+    transform: translateY(-6px) scale(1.05);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+.form-hint {
+  margin: 0;
+  text-align: center;
+  color: #ff9b9b;
+  font-weight: 500;
+  min-height: 1.2rem;
+}
+
+.panel--results {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.panel--results.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#compatibilityResult {
+  background: rgba(20, 14, 38, 0.65);
+  box-shadow: 0 25px 65px rgba(8, 12, 35, 0.6);
+  backdrop-filter: blur(calc(var(--glass-blur) + 6px));
+}
+
+.results__text {
+  line-height: 1.7;
+  color: var(--text-muted);
+  margin: 0 0 1rem;
+}
+
+.results__highlights {
+  margin: 0 0 1.5rem;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.7rem;
+  color: var(--text-muted);
+}
+
+.results__highlights li::marker {
+  color: var(--accent);
+}
+
+.results__cards {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.cards-grid {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tarot-card {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 24px;
+  background: linear-gradient(155deg, rgba(23, 20, 40, 0.85), rgba(44, 36, 78, 0.65));
+  box-shadow: var(--shadow-soft), var(--card-glow);
+  display: grid;
+  gap: 0.9rem;
+  transition: transform 0.55s ease, box-shadow 0.55s ease, opacity 0.55s ease;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.tarot-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(160deg, rgba(200, 155, 255, 0.55), rgba(127, 123, 255, 0.35), rgba(107, 194, 255, 0.45));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.tarot-card--hidden {
+  opacity: 0;
+  transform: translateY(45px) scale(0.95);
+}
+
+.tarot-card:hover {
+  transform: translateY(-12px) scale(1.02);
+  box-shadow: 0 25px 55px rgba(117, 108, 255, 0.45), 0 0 45px rgba(200, 155, 255, 0.4);
+}
+
+.tarot-card__figure {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tarot-card__image {
+  border-radius: 18px;
+  overflow: hidden;
+  aspect-ratio: 2 / 3;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 0%, rgba(200, 155, 255, 0.35), rgba(23, 18, 46, 0.85));
+  border: 1px solid rgba(200, 155, 255, 0.3);
+  box-shadow: inset 0 0 25px rgba(10, 8, 25, 0.65);
+  transition: transform 0.5s ease;
+}
+
+.tarot-card:hover .tarot-card__image {
+  transform: translateY(-8px);
+}
+
+.tarot-card__image img {
+  width: auto;
+  height: 100%;
+  filter: drop-shadow(0 12px 20px rgba(0, 0, 0, 0.35));
+  transition: transform 0.5s ease;
+}
+
+.tarot-card__image--reversed img {
+  transform: rotate(180deg);
+}
+
+.tarot-card:hover .tarot-card__image img {
+  transform: translateY(-4px) scale(1.02);
+}
+
+.tarot-card__caption {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--text-primary);
+}
+
+.tarot-card__name {
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: 1.2rem;
+  letter-spacing: 0.03em;
+}
+
+.tarot-card__orientation {
+  font-size: 0.9rem;
+  color: rgba(244, 240, 255, 0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tarot-card__keywords,
+.tarot-card__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+  font-size: 0.98rem;
+}
+
+.page-footer {
+  text-align: center;
+  margin-top: auto;
+}
+
+.back-to-top {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 500;
+  color: var(--text-primary);
+  border: 1px solid rgba(200, 155, 255, 0.3);
+  box-shadow: var(--card-glow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.back-to-top:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0 30px rgba(200, 155, 255, 0.35);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: clamp(1.25rem, 4vw, 2rem);
   }
 
-#spread_selection {
-    grid-row-start:2;
-    display:grid;
-    grid-row-gap:none;
-    grid-template-areas:
-    "rule_of_three"
-    "true_love"
-    "success"
-}
-#spread_selection > div > p {
-    font-size: .75em;
-    font-weight: lighter;
-    font-style:italic;
-    padding-left:1em;
-    padding-right:1em;
-}
+  .panel {
+    padding: clamp(1.5rem, 5vw, 2.25rem);
+  }
 
-#spread_selection > div > h6 {
-    padding-left:.7em;
-    padding-right:.5em;
-    padding-top:.3em;
+  .panel__text {
+    font-size: 0.98rem;
+  }
+
+  .form-card {
+    padding: clamp(1.1rem, 5vw, 1.5rem);
+  }
+
+  .cta-button {
+    width: 100%;
+  }
 }
 
-#spread_selection > div:hover {
-    cursor:pointer;
+@media (max-width: 480px) {
+  .hero__brand {
+    font-size: clamp(2.2rem, 10vw, 2.8rem);
+  }
+
+  .panel {
+    border-radius: 20px;
+  }
+
+  .panel::before {
+    border-radius: 18px;
+  }
+
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
-#spread_selection > div:nth-child(odd) {
-    background-color: #bfced3;
-}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
 
-
-#deck_here {
-    display:none;
-}
-
-#deck_area {
-    display: block;
-    align-items: center;
-    justify-content: center;
-    text-align:center;
-}
-
-.deck {
-    margin-top:2.5em;
-    height: 25%;
-    width:25%;
-    border-radius: 15px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    border-radius: 5px;
-    -webkit-transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-    transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-}
-
-.deck::after {
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-    opacity: 0;
-    -webkit-transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-    transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-}
-
-.deck:hover {
-    cursor:pointer;
-    -webkit-transform: scale(1.25, 1.25);
-    transform: scale(1.25, 1.25);
-}
-
-.deck:hover::after {
+  .panel--results {
     opacity: 1;
-}
-
-#rule_of_three {
-    margin:.5em;
-    grid-gap:.75em;
-    display:grid;
-    grid-template-columns: 1 1 1;
-    grid-template-areas:
-    "firstd secondd thirdd"
-    "first second third"
-
-}
-
-#rule_of_three [class="1"] {
-    grid-area: first;
-    grid-column: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#rule_of_three [class="2"] {
-    grid-area: second;
-    grid-column:2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#rule_of_three [class="3"]  {
-    grid-area: third;
-    grid-column:3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#rule_of_three > p [class="1_description"] {
-    grid-area: firstd;
-    grid-column:1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#rule_of_three > p [class="2_description"] {
-    grid-area: secondd;
-    grid-column: 2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#rule_of_three > p [class="3_description"] {
-    grid-area: thirdd;
-    grid-column: 3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#true_love_spread {
-    margin:.5em;
-    grid-gap:.5em;
-    display:inline-grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-    grid-template-areas:
-    "first second"
-    "third fourth fifth"
-    "sixth"
-}
-
-#tl_first_card {
-    grid-area:first;
-    grid-row: 1;
-    grid-column: 1/2;
-
-}
-
-#tl_second_card {
-    grid-area:second;
-    grid-row:1;
-    grid-column:3/4;
-
-}
-
-#tl_third_card   {
-    grid-area:third;
-    grid-column: 1;
-    grid-row:2;
-
-}
-
-#tl_fourth_card {
-    grid-area:fourth;
-    grid-column:2;
-    grid-row:2;
-
-}
-
-#tl_fifth_card {
-    grid-area:fifth;
-    grid-column:3;
-    grid-row:2;
-}
-
-#tl_sixth_card {
-    grid-area:sixth;
-    grid-row:3;
-    grid-column:2;
-
-}
-
-#tl_first_card, #tl_second_card, #tl_third_card, #tl_fourth_card, #tl_fifth_card, #tl_sixth_card > img{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#tl_first_card, #tl_second_card, #tl_third_card, #tl_fourth_card, #tl_fifth_card, #tl_sixth_card > p {
-    display: block;
-    align-items: center;
-    justify-content: center;
-    margin:0;
-    padding:0;
-}
-
-#success_spread {
-    display:grid;
-    margin:.5em;
-    grid-gap:.5em;
-    display:inline-grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-areas:
-    "fourth"
-    "second first third"
-    "fifth";
-}
-
-#suc_first {
-    grid-area:first;
-    grid-row: 2;
-    grid-column: 2;
-
-}
-
-#suc_second {
-    grid-area:second;
-    grid-row:2;
-    grid-column:1;
-
-}
-
-#suc_third   {
-    grid-area:third;
-    grid-column: 3;
-    grid-row:2;
-
-}
-
-#suc_fourth {
-    grid-area:fourth;
-    grid-column:1;
-    grid-row:1;
-}
-
-#suc_fifth {
-    grid-area:fifth;
-    grid-column:1;
-    grid-row:3;
-}
-
-#suc_first, #suc_second, #suc_third, #suc_fourth, #suc_fifth > img{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#suc_first, #suc_second, #suc_third, #suc_fourth, #suc_fifth > p {
-    display: block;
-    align-items: center;
-    justify-content: center;
-    margin:0;
-    padding:0;
-}
-
-.new_reading_button {
-  display:none;
-  margin:1em;
-}
-
-/* iPads (portrait and landscape) ----------- */
-@media only screen and (min-device-width : 768px) and (max-device-width : 1024px) {
-/* Styles */
-}
-
-
-/* Desktops and laptops ----------- */
-@media only screen  and (min-width : 1224px) {
-/* Styles */
+    transform: none;
+  }
 }

--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -1,0 +1,278 @@
+(() => {
+  const form = document.getElementById('compatibility-form');
+  const hint = document.querySelector('[data-hint]');
+  const resultsSection = document.getElementById('compatibilityResult');
+  const summaryEl = document.getElementById('compatibility-summary');
+  const highlightsEl = document.getElementById('compatibility-highlights');
+  const cardsContainer = document.getElementById('cards-container');
+  const adviceEl = document.getElementById('compatibility-advice');
+  const drawButton = form?.querySelector('button[type="submit"]') ?? null;
+  const prefersReducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if (!form) {
+    return;
+  }
+
+  const sanitize = (value) => value.trim();
+
+  const getRandomInt = (min, max) => {
+    const minCeil = Math.ceil(min);
+    const maxFloor = Math.floor(max);
+    return Math.floor(Math.random() * (maxFloor - minCeil + 1)) + minCeil;
+  };
+
+  const drawCards = (count) => {
+    const selected = [];
+    const usedIndexes = new Set();
+
+    while (selected.length < count) {
+      const index = getRandomInt(0, rider_waite_cards.length - 1);
+      if (usedIndexes.has(index)) {
+        continue;
+      }
+      usedIndexes.add(index);
+      const card = rider_waite_cards[index];
+      selected.push({
+        name: card.name,
+        img: card.img,
+        description: card.meta_description,
+        uprightMeaning: card.meta_upright?.trim() ?? '',
+        reversedMeaning: card.meta_reversed?.trim() ?? '',
+        isReversed: Math.random() < 0.5
+      });
+    }
+
+    return selected;
+  };
+
+  const cardsWord = (count) => {
+    const mod10 = count % 10;
+    const mod100 = count % 100;
+
+    if (mod10 === 1 && mod100 !== 11) {
+      return 'карту';
+    }
+    if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) {
+      return 'карты';
+    }
+    return 'карт';
+  };
+
+  const createSummary = (cards, userName, partnerName) => {
+    const pair = `${userName} и ${partnerName}`;
+    const score = cards.reduce((total, card) => total + (card.isReversed ? -1 : 1), 0);
+    const base = `Колода выбрала ${cards.length} ${cardsWord(cards.length)} для ${pair}. `;
+
+    if (score >= 4) {
+      return base + 'Энергия союза сияет: чувства взаимны, а потенциал отношений очень высок.';
+    }
+    if (score >= 2) {
+      return base + 'Расклад благоприятен — между вами много поддержки, понимания и искренней симпатии.';
+    }
+    if (score >= 1) {
+      return base + 'В паре ощущается здоровый баланс, хотя вам важно бережно относиться к чувствам друг друга.';
+    }
+    if (score === 0) {
+      return base + 'Сейчас энергии уравновешены: итог отношений зависит от того, как вы распределите ответственность и внимание.';
+    }
+    if (score >= -2) {
+      return base + 'Карты показывают несколько напряжённых моментов. Откровенный разговор и готовность к компромиссам помогут их сгладить.';
+    }
+    return base + 'Расклад предупреждает о серьёзных испытаниях. Не бойтесь обсуждать сложные темы и устанавливать ясные границы.';
+  };
+
+  const formatCardsList = (cards, getMeaning) => {
+    return cards.map((card) => `${card.name} — ${getMeaning(card)}`).join('; ');
+  };
+
+  const createAdvice = (cards) => {
+    const positives = cards.filter((card) => !card.isReversed);
+    const challenges = cards.filter((card) => card.isReversed);
+    const adviceParts = [];
+
+    if (positives.length) {
+      adviceParts.push(`Опирайтесь на ${formatCardsList(positives, (card) => card.uprightMeaning)}. Эти карты усиливают вашу связь.`);
+    } else {
+      adviceParts.push('Сейчас ключ к гармонии — создание позитивных ритуалов и поддерживающих привычек в отношениях.');
+    }
+
+    if (challenges.length) {
+      adviceParts.push(`Будьте внимательны к ${formatCardsList(challenges, (card) => card.reversedMeaning)}. Их энергия намекает на темы, требующие совместных решений.`);
+    } else {
+      adviceParts.push('Перевёрнутых карт нет, поэтому препятствий немного — используйте момент, чтобы укрепить доверие.');
+    }
+
+    return adviceParts.join(' ');
+  };
+
+  const renderHighlights = (cards, highlightsNode) => {
+    highlightsNode.innerHTML = '';
+
+    const positives = cards.filter((card) => !card.isReversed);
+    const challenges = cards.filter((card) => card.isReversed);
+
+    const positivesItem = document.createElement('li');
+    positivesItem.textContent = positives.length
+      ? `Сильные стороны: ${positives.map((card) => card.name).join(', ')}.`
+      : 'Сильные стороны пока не проявлены — создайте их сами общими усилиями.';
+    highlightsNode.appendChild(positivesItem);
+
+    const challengesItem = document.createElement('li');
+    challengesItem.textContent = challenges.length
+      ? `Зоны роста: ${challenges.map((card) => card.name).join(', ')}.`
+      : 'Сложные карты не выпали — серьёзных препятствий не видно.';
+    highlightsNode.appendChild(challengesItem);
+
+    cards.forEach((card) => {
+      const cardItem = document.createElement('li');
+      const orientation = card.isReversed ? 'Перевёрнутое положение' : 'Прямое положение';
+      const meaning = card.isReversed ? card.reversedMeaning : card.uprightMeaning;
+      cardItem.textContent = `${card.name}: ${orientation}. ${meaning}`;
+      highlightsNode.appendChild(cardItem);
+    });
+  };
+
+  const revealResultsPanel = () => {
+    if (!resultsSection) {
+      return;
+    }
+
+    if (resultsSection.hidden) {
+      resultsSection.hidden = false;
+    }
+
+    if (!prefersReducedMotionQuery.matches) {
+      resultsSection.classList.remove('is-visible');
+      void resultsSection.offsetWidth;
+      resultsSection.classList.add('is-visible');
+    } else {
+      resultsSection.classList.add('is-visible');
+    }
+  };
+
+  const triggerDrawAnimation = () => {
+    if (!drawButton) {
+      return;
+    }
+
+    drawButton.classList.remove('cta-button--drawing');
+    void drawButton.offsetWidth;
+    drawButton.classList.add('cta-button--drawing');
+  };
+
+  const renderCards = (cards, container) => {
+    container.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    const createdElements = [];
+
+    cards.forEach((card) => {
+      const article = document.createElement('article');
+      article.className = 'tarot-card';
+      article.classList.add('tarot-card--hidden');
+
+      const figure = document.createElement('figure');
+      figure.className = 'tarot-card__figure';
+
+      const imageWrapper = document.createElement('div');
+      imageWrapper.className = 'tarot-card__image';
+      if (card.isReversed) {
+        imageWrapper.classList.add('tarot-card__image--reversed');
+      }
+
+      const image = document.createElement('img');
+      image.src = card.img;
+      image.loading = 'lazy';
+      image.alt = card.isReversed ? `${card.name} — перевёрнутое положение` : `${card.name}`;
+
+      imageWrapper.appendChild(image);
+      figure.appendChild(imageWrapper);
+
+      const caption = document.createElement('figcaption');
+      caption.className = 'tarot-card__caption';
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'tarot-card__name';
+      nameEl.textContent = card.name;
+
+      const orientationEl = document.createElement('span');
+      orientationEl.className = 'tarot-card__orientation';
+      orientationEl.textContent = card.isReversed ? 'Перевёрнутое положение' : 'Прямое положение';
+
+      caption.append(nameEl, orientationEl);
+      figure.appendChild(caption);
+
+      article.appendChild(figure);
+
+      const keywords = document.createElement('p');
+      keywords.className = 'tarot-card__keywords';
+      keywords.textContent = card.isReversed ? card.reversedMeaning : card.uprightMeaning;
+      article.appendChild(keywords);
+
+      const description = document.createElement('p');
+      description.className = 'tarot-card__description';
+      description.textContent = card.description;
+      article.appendChild(description);
+
+      fragment.appendChild(article);
+      createdElements.push(article);
+    });
+
+    container.appendChild(fragment);
+
+    if (prefersReducedMotionQuery.matches) {
+      createdElements.forEach((element) => element.classList.remove('tarot-card--hidden'));
+      return;
+    }
+
+    createdElements.forEach((element, index) => {
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          element.classList.remove('tarot-card--hidden');
+        }, index * 150);
+      });
+    });
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const userName = sanitize(form.userName.value);
+    const partnerName = sanitize(form.partnerName.value);
+    const userBirthday = form.userBirthday.value;
+    const partnerBirthday = form.partnerBirthday.value;
+
+    if (!userName || !partnerName || !userBirthday || !partnerBirthday) {
+      if (hint) {
+        hint.textContent = 'Пожалуйста, заполните все поля — именно так карты смогут отразить вашу историю.';
+      }
+      if (resultsSection) {
+        resultsSection.hidden = true;
+        resultsSection.classList.remove('is-visible');
+      }
+      return;
+    }
+
+    triggerDrawAnimation();
+
+    if (hint) {
+      hint.textContent = '';
+    }
+
+    const cardsToDraw = getRandomInt(3, 5);
+    const drawnCards = drawCards(cardsToDraw);
+
+    summaryEl.textContent = createSummary(drawnCards, userName, partnerName);
+    renderHighlights(drawnCards, highlightsEl);
+    renderCards(drawnCards, cardsContainer);
+    adviceEl.textContent = createAdvice(drawnCards);
+
+    revealResultsPanel();
+
+    if (resultsSection) {
+      const scrollBehavior = prefersReducedMotionQuery.matches ? 'auto' : 'smooth';
+      resultsSection.scrollIntoView({ behavior: scrollBehavior, block: 'start' });
+    }
+  };
+
+  form.addEventListener('submit', handleSubmit);
+})();

--- a/reading.html
+++ b/reading.html
@@ -1,146 +1,91 @@
 <!doctype html>
-<html lang="en">
-    <head>
-        <meta charset='utf-8'>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="X-UA-Compatible" content="id=edge">
-        <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon">
-        <link rel="manifest" href="/manifest.webmanifest">
-        <title>Madame Sosotris</title>
-        <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css">
-        <link rel="stylesheet" href="css/reading.css" type="text/css">
-        <script src="js/jquery-3.3.1.js"></script>
-        <script src="js/bootstrap.bundle.min.js"></script>
-        <script src="js/scripts.js"></script>
-        <script src="js/tarot-cards.js"></script>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon">
+    <link rel="manifest" href="/manifest.webmanifest">
+    <title>Совместимость по картам Таро</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="css/reading.css" type="text/css">
+    <script defer src="js/scripts.js"></script>
+    <script defer src="js/compatibility.js"></script>
+  </head>
+  <body>
+    <div class="page" id="top">
+      <header class="hero">
+        <a class="hero__brand" href="splash.html" aria-label="Вернуться на главную">Madame Sosotris</a>
+        <p class="hero__subtitle">Мистический расклад для тех, кто ищет ответы вместе.</p>
+      </header>
 
-    </head>
-    <body>
-           <!-- Disgusting bootstrap modal-->
-        <div class="modal fade" id="explanationModal" tabindex="-1" role="dialog" aria-labelledby="explanationModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h5 class="modal-title" id="explanationModalLabel"><span class="card_name_here"></span>
-                  </h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                  </button>
-                </div>
-                <div class="modal-body">
-                  <span class="img_here"></span>
-                  <div id="upright_meaning_div">
-                    <h6>Upright Keywords</h6>
-                    <p class="small"><span class="upright_meaning_here"></span></p>
-                  </div>
-                  <div id="reversed_meaning_div">
-                    <h6>Reversed Keywords</h6>
-                    <p class="small"><span class="reversed_meaning_here"></span></p>
-                  </div>
-                  <h6>Description</h6>
-                  <p><span class="meta_description_here"></span></p>
-                <div class="modal-footer">
-                  <span class="more_info_link_here"></span>
-                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                </div>
-              </div>
+      <main class="layout">
+        <section class="panel panel--intro" aria-labelledby="intro-title">
+          <h1 id="intro-title" class="panel__title">Совместимость по картам Таро</h1>
+          <p class="panel__text">
+            Введите имена и даты рождения, чтобы получить персональный расклад: карты покажут магию вашей связи,
+            подскажут, где скрываются тени, и подарят совет для гармонии.
+          </p>
+        </section>
+
+        <section class="panel panel--form" aria-labelledby="compatibility-form-title">
+          <h2 id="compatibility-form-title" class="panel__subtitle">Данные для анализа</h2>
+          <form id="compatibility-form" class="reading-form" novalidate>
+            <div class="form-grid">
+              <fieldset class="form-card">
+                <legend>Вы</legend>
+                <label class="form-label" for="user-name">Имя</label>
+                <input class="form-input" id="user-name" name="userName" type="text" placeholder="Например, Анна" required>
+                <label class="form-label" for="user-birthday">Дата рождения</label>
+                <input class="form-input" id="user-birthday" name="userBirthday" type="date" required>
+              </fieldset>
+              <fieldset class="form-card">
+                <legend>Партнёр</legend>
+                <label class="form-label" for="partner-name">Имя</label>
+                <input
+                  class="form-input"
+                  id="partner-name"
+                  name="partnerName"
+                  type="text"
+                  placeholder="Например, Алексей"
+                  required
+                >
+                <label class="form-label" for="partner-birthday">Дата рождения</label>
+                <input class="form-input" id="partner-birthday" name="partnerBirthday" type="date" required>
+              </fieldset>
             </div>
+            <div class="form-actions">
+              <button class="cta-button" type="submit">Проверить совместимость</button>
+            </div>
+            <p class="form-hint" data-hint role="alert" aria-live="assertive"></p>
+          </form>
+        </section>
+
+        <section id="compatibilityResult" class="panel panel--results" aria-live="polite" hidden>
+          <div class="results__summary">
+            <h2 class="results__title">Итоги расклада</h2>
+            <p id="compatibility-summary" class="results__text"></p>
+            <ul id="compatibility-highlights" class="results__highlights"></ul>
           </div>
-        </div>
-        <div class="wrapper">
-            <div class="header">
-                <h1 onclick="goHome()">Madame Sosotris</h1>
-                <hr>
-            </div>
-            <!-- Here is the menu for selecting a spread-->
-            <div id="spread_selection">
-                <div class="rule_of_three">
-                    <h6>Rule of Three</h6>
-                    <p>A reading which offers one card each for the past, present, and future</p>
-                </div>
-                <div class="true_love">
-                    <h6>True Love</h6>
-                    <p>A reading which offers advice about our love lives</p>
-                </div>
-                <div class="success">
-                    <h6>Success</h6>
-                    <p>A reading which offers insights into our current professional and personal struggles</p>
-                </div>
-            </div>
-            <!--Here is the deck div-->
-            <div id="deck_here">
-                <div id="deck_area">
-                    <img src="img/tarot_deck.jpg" class="deck rounded" alt="The back of the tarot deck." id="deckDraw">
-                </div>
-            </div>
-                <!--Here are the different spreads designed to display properly with horrible bootstrap-->
-            <div class="spread_display">
-                <!--Three card spread-->
-                <div id="rule_of_three">
-                    <p class="card_position"><span class="1_description"></span></p>
-                    <span class="1"></span>
-                    <p class="card_position"><span class="2_description"></span></p>
-                    <span class="2"></span>
-                    <p class="card_position"><span class="3_description"></span></p>
-                    <span class="3"></span>
-                </div>
-                <!--True Love Spread-->
-                <div id="true_love_spread">
-                    <div id="tl_first_card">
-                        <p class="card_position"><span class="1_description"></span></p>
-                        <span class="1"></span>
-                    </div>
-                    <div id="tl_second_card">
-                        <p class="card_position"><span class="2_description"></span></p>
-                        <span class="2"></span>
-                    </div>
-                    <div id="tl_third_card">
-                        <p class="card_position"><span class="3_description"></span></p>
-                        <span class="3"></span>
-                    </div>
-                    <div id="tl_fourth_card">
-                        <p class="card_position"><span class="4_description"></span></p>
-                        <span class="4"></span>
-                    </div>
-                    <div id="tl_fifth_card">
-                        <p class="card_position"><span class="5_description"></span></p>
-                        <span class="5"></span>
-                    </div>
-                    <div id="tl_sixth_card">
-                        <p class="card_position"><span class="6_description"></span></p>
-                        <span class="6"></span>
-                    </div>
-                </div>
-                <!--Success Spread-->
-                <div id="success_spread">
-                    <div id="suc_fourth">
-                        <p class="card_position"><span class="4_description"></span></p>
-                        <span class="4"></span>
-                    </div>
-                    <div id="suc_second">
-                        <p class="card_position"><span class="2_description"></span></p>
-                        <span class="2"></span>
-                    </div>
-                    <div id="suc_first">
-                        <p class="card_position"><span class="1_description"></span></p>
-                        <span class="1"></span>
-                    </div>
-                    <div id="suc_third">
-                        <p class="card_position"><span class="3_description"></span></p>
-                        <span class="3"></span>
-                    </div>
-                    <div id="suc_fifth">
-                        <p class="card_position"><span  class="5_description"></span></p>
-                        <span class="5"></span>
-                    </div>
-                </div>
-            </div>
-            <div class="footer">
-              <div class="new_reading_button">
-                <hr>
-                <a href="reading.html" class="btn btn-dark">Try a Different Reading</a>
-              </div>
-            </div>
-        </div>
-    </body>
+          <div class="results__cards">
+            <h3 class="results__subtitle">Карты расклада</h3>
+            <div id="cards-container" class="cards-grid" aria-live="polite"></div>
+          </div>
+          <div class="results__advice">
+            <h3 class="results__subtitle">Совет от Таро</h3>
+            <p id="compatibility-advice" class="results__text"></p>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-to-top" href="#top">Вернуться к началу</a>
+      </footer>
+    </div>
+  </body>
 </html>

--- a/splash.html
+++ b/splash.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -69,11 +69,11 @@
         </blockquote>
       </div>
       <div class="new_reading_button">
-        <a href="reading.html" class="btn btn-dark">New Reading</a>
+        <a href="reading.html" class="btn btn-dark">Проверить совместимость</a>
       </div>
       <div class="card_of_the_day">
         <hr>
-        <h2>card of the moment</h2>
+        <h2>карта момента</h2>
         <span class="card_image_here"></span>
       </div>
       <div id="footer">


### PR DESCRIPTION
## Summary
- redesign `reading.html` into a cinematic tarot compatibility layout with updated typography and structure
- apply a new mystical dark theme in `css/reading.css`, adding glassmorphism panels, glowing buttons, hover effects, and responsive tweaks
- enhance `js/compatibility.js` to animate the draw button, reveal cards sequentially, and smoothly display results while respecting reduced-motion settings

## Testing
- Manual verification by launching `python3 -m http.server 8000` and viewing reading.html

------
https://chatgpt.com/codex/tasks/task_e_68e4fba50ad08325993fd9d90a3e952b